### PR TITLE
Make importlib a conditional import

### DIFF
--- a/flake8_printf_formatting.py
+++ b/flake8_printf_formatting.py
@@ -1,7 +1,10 @@
 import ast
 from typing import Any, Generator, List, Tuple, Type
 
-import importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata  # python_version<'3.8'
 
 MOD001 = "MOD001 do not use printf-style string formatting"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 py_modules = flake8_printf_formatting
 install_requires =
     flake8
-    importlib-metadata
+    importlib-metadata; python_version  < "3.8"
 python_requires = >=3.6
 
 [options.entry_points]


### PR DESCRIPTION
Fixes #3 

This PR fixes an import error for Python 3.8 and above. In Python 3.8, the `importlib_metadata` package was implemented in the standard library as `importlib.metadata` ([Python docs](https://docs.python.org/3.8/library/importlib.metadata.html))